### PR TITLE
Feat: 포켓몬 검색 시 단어 일부만으로 검색되도록 구현

### DIFF
--- a/src/api/pokemon.ts
+++ b/src/api/pokemon.ts
@@ -60,6 +60,17 @@ export async function getPokemonIdByKoreanName(
   return null;
 }
 
+export async function getPokemonsByIds(ids: number[]) {
+  console.log(ids);
+  return Promise.all(
+    ids.map((id) =>
+      fetch(`https://pokeapi.co/api/v2/pokemon/${id}`).then((res) =>
+        res.json(),
+      ),
+    ),
+  );
+}
+
 export async function getPokemonEvolutionChain(
   url: string,
 ): Promise<EvolutionChainProps> {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -8,7 +8,7 @@ export interface ButtonProps {
   size?: ButtonSize;
   type: 'button' | 'submit' | 'reset';
   label: string;
-  disabled: boolean;
+  disabled?: boolean;
   onClick?: () => void;
 }
 
@@ -18,7 +18,7 @@ export const Button = ({
   type = 'button',
   backgroundColor,
   label,
-  disabled,
+  disabled = false,
   ...props
 }: ButtonProps) => {
   const ButtonStyle: string = primary

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,10 +1,9 @@
 import { twJoin } from 'tailwind-merge';
 
-import { ButtonSize } from '@/types/common';
+import { ButtonSize, DefaultProps } from '@/types/common';
 
-export interface ButtonProps {
+export interface ButtonProps extends DefaultProps {
   primary?: boolean;
-  backgroundColor?: string;
   size?: ButtonSize;
   type: 'button' | 'submit' | 'reset';
   label: string;
@@ -16,9 +15,9 @@ export const Button = ({
   primary = false,
   size = 'medium',
   type = 'button',
-  backgroundColor,
-  label,
   disabled = false,
+  label,
+  className,
   ...props
 }: ButtonProps) => {
   const ButtonStyle: string = primary
@@ -36,7 +35,12 @@ export const Button = ({
   return (
     <button
       type={type}
-      className={twJoin(buttonSizeClasses[size], ButtonStyle, disabledStyle)}
+      className={twJoin(
+        buttonSizeClasses[size],
+        ButtonStyle,
+        disabledStyle,
+        className,
+      )}
       disabled={disabled}
       {...props}>
       {label}

--- a/src/components/PagingDocuments/PagingDocuments.tsx
+++ b/src/components/PagingDocuments/PagingDocuments.tsx
@@ -10,29 +10,21 @@ import {
 
 export interface PagingDocumentsProps {
   now: number;
-  last: boolean;
   total: number;
   pageSize: number;
 
   setNow: (now: number) => void;
-  setLast: (last: boolean) => void;
 }
 
 export const PagingDocuments = ({
   now,
-  last,
   total,
   pageSize,
   setNow,
-  setLast,
 }: PagingDocumentsProps) => {
-  const { pages, goToPage } = usePagination(
-    total,
-    now,
-    pageSize,
-    setNow,
-    setLast,
-  );
+  const { pages, goToPage } = usePagination(total, now, pageSize, setNow);
+  const lastPage = Math.ceil(total / pageSize);
+
   return (
     <ul className="mt-5 px-14 text-lg flex justify-center items-center gap-2">
       {now > 1 && (
@@ -59,7 +51,7 @@ export const PagingDocuments = ({
         </PageButton>
       ))}
 
-      {!last && (
+      {now < lastPage && (
         <>
           <IconButton
             primary={false}
@@ -69,7 +61,7 @@ export const PagingDocuments = ({
           <IconButton
             primary={false}
             Icon={FaAnglesRight}
-            onClick={() => goToPage(Math.ceil(total / pageSize))}
+            onClick={() => goToPage(lastPage)}
           />
         </>
       )}

--- a/src/components/PagingDocuments/PagingDocuments.tsx
+++ b/src/components/PagingDocuments/PagingDocuments.tsx
@@ -1,7 +1,5 @@
 import { usePagination } from '@/hooks/usePagination';
 
-import usePokemonsStore from '@/stores/pokemonsStore';
-
 import { IconButton, PageButton } from '../PageButton/PageButton';
 import {
   FaAngleLeft,
@@ -10,9 +8,22 @@ import {
   FaAnglesRight,
 } from 'react-icons/fa6';
 
-export const PagingDocuments = () => {
-  const { now, last, setNow, total, setLast } = usePokemonsStore();
+export interface PagingDocumentsProps {
+  now: number;
+  last: boolean;
+  total: number;
 
+  setNow: (now: number) => void;
+  setLast: (last: boolean) => void;
+}
+
+export const PagingDocuments = ({
+  now,
+  last,
+  total,
+  setNow,
+  setLast,
+}: PagingDocumentsProps) => {
   const { pages, goToPage } = usePagination(
     total,
     now,

--- a/src/components/PagingDocuments/PagingDocuments.tsx
+++ b/src/components/PagingDocuments/PagingDocuments.tsx
@@ -12,6 +12,7 @@ export interface PagingDocumentsProps {
   now: number;
   last: boolean;
   total: number;
+  pageSize: number;
 
   setNow: (now: number) => void;
   setLast: (last: boolean) => void;
@@ -21,13 +22,14 @@ export const PagingDocuments = ({
   now,
   last,
   total,
+  pageSize,
   setNow,
   setLast,
 }: PagingDocumentsProps) => {
   const { pages, goToPage } = usePagination(
     total,
     now,
-    PAGE_ITEM_SIZE,
+    pageSize,
     setNow,
     setLast,
   );
@@ -67,12 +69,10 @@ export const PagingDocuments = ({
           <IconButton
             primary={false}
             Icon={FaAnglesRight}
-            onClick={() => goToPage(Math.ceil(total / PAGE_ITEM_SIZE))}
+            onClick={() => goToPage(Math.ceil(total / pageSize))}
           />
         </>
       )}
     </ul>
   );
 };
-
-export const PAGE_ITEM_SIZE = 10;

--- a/src/components/Pokemon/Pokemon.tsx
+++ b/src/components/Pokemon/Pokemon.tsx
@@ -16,9 +16,9 @@ export interface PokemonProps {
 }
 
 export const Pokemon = ({ id }: PokemonProps) => {
-  if (id === null || id >= TOTAL_POKEMON_NUM) return;
+  if (id >= TOTAL_POKEMON_NUM) return;
 
-  const [pokemon, setPokemon] = useState<PokemonDataProps>();
+  const [pokemon, setPokemon] = useState<PokemonDataProps | null>(null);
 
   const {
     pokemonData,
@@ -35,13 +35,14 @@ export const Pokemon = ({ id }: PokemonProps) => {
   }, [pokemonData, speciesData]);
 
   if (isLoadingPokemon || isLoadingSpecies) return <div>Loading...</div>;
-  if (isErrorPokemon) return <div>Error loading Pokemon data.</div>;
-  if (isErrorSpecies) return <div>Error loading Pokemon species data.</div>;
+  if (isErrorPokemon || isErrorSpecies)
+    return <div>Failed to load data. Please try again later.</div>;
 
-  if (pokemon)
-    return (
-      <Link href={`/pokemon/${id}`}>
-        <PokemonImgBox pokemon={pokemon} usage="list" id={id} />
-      </Link>
-    );
+  if (!pokemon) return null;
+
+  return (
+    <Link href={`/pokemon/${id}`}>
+      <PokemonImgBox pokemon={pokemon} usage="list" id={id} />
+    </Link>
+  );
 };

--- a/src/components/PokemonList/PokemonList.tsx
+++ b/src/components/PokemonList/PokemonList.tsx
@@ -9,7 +9,7 @@ import { PokemonsResponseProps } from '@/types/common';
 import extractIdFromUrl from '@/utils/extractIdFromUrl';
 
 export interface PokemonListProps {
-  pokemonIdsList: number[] | null;
+  pokemonIdsList: number[] | null | undefined;
   now: number;
 }
 
@@ -17,26 +17,28 @@ export const PokemonList = ({ pokemonIdsList, now }: PokemonListProps) => {
   const { isLoading, error, data } = useQuery<PokemonsResponseProps>({
     queryKey: ['pokemons', now],
     queryFn: () => getPokemons(now),
-    enabled: !pokemonIdsList,
+    enabled: !pokemonIdsList?.length,
   });
+
   if (isLoading) return <div>loading...</div>;
   if (error) return <div>error</div>;
-  if (data)
-    return (
-      <>
-        <div className="grid grid-cols-5 py-2 px-14 gap-8">
-          {pokemonIdsList &&
-            pokemonIdsList.map((pokemonId) => (
-              <Pokemon key={pokemonId} id={pokemonId} />
-            ))}
-          {!pokemonIdsList &&
-            data.data.map((pokemon) => (
-              <Pokemon
-                key={extractIdFromUrl(pokemon.url)}
-                id={extractIdFromUrl(pokemon.url) as number}
-              />
-            ))}
-        </div>
-      </>
-    );
+
+  return (
+    <>
+      <div className="grid grid-cols-5 py-2 px-14 gap-8">
+        {pokemonIdsList &&
+          pokemonIdsList?.map((pokemonId) => (
+            <Pokemon key={pokemonId} id={pokemonId} />
+          ))}
+        {!pokemonIdsList &&
+          data &&
+          data?.data.map((pokemon) => (
+            <Pokemon
+              key={extractIdFromUrl(pokemon.url)}
+              id={extractIdFromUrl(pokemon.url) as number}
+            />
+          ))}
+      </div>
+    </>
+  );
 };

--- a/src/components/PokemonList/PokemonList.tsx
+++ b/src/components/PokemonList/PokemonList.tsx
@@ -26,18 +26,16 @@ export const PokemonList = ({ pokemonIdsList, now }: PokemonListProps) => {
   return (
     <>
       <div className="grid grid-cols-5 py-2 px-14 gap-8">
-        {pokemonIdsList &&
-          pokemonIdsList?.map((pokemonId) => (
-            <Pokemon key={pokemonId} id={pokemonId} />
-          ))}
-        {!pokemonIdsList &&
-          data &&
-          data?.data.map((pokemon) => (
-            <Pokemon
-              key={extractIdFromUrl(pokemon.url)}
-              id={extractIdFromUrl(pokemon.url) as number}
-            />
-          ))}
+        {pokemonIdsList?.length
+          ? pokemonIdsList.map((pokemonId) => (
+              <Pokemon key={pokemonId} id={pokemonId} />
+            ))
+          : data?.data.map((pokemon) => (
+              <Pokemon
+                key={extractIdFromUrl(pokemon.url)}
+                id={extractIdFromUrl(pokemon.url)}
+              />
+            ))}
       </div>
     </>
   );

--- a/src/components/PokemonList/PokemonList.tsx
+++ b/src/components/PokemonList/PokemonList.tsx
@@ -2,36 +2,34 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getPokemons } from '@/api/pokemon';
 
-import usePokemonsStore from '@/stores/pokemonsStore';
-
 import { Pokemon } from '../Pokemon/Pokemon';
-import { PagingDocuments } from '../PagingDocuments/PagingDocuments';
 
 import { PokemonsResponseProps } from '@/types/common';
 
 import extractIdFromUrl from '@/utils/extractIdFromUrl';
 
 export interface PokemonListProps {
-  pokemonId: number | undefined | null;
+  pokemonIdsList: number[] | null;
+  now: number;
 }
 
-export const PokemonList = ({ pokemonId }: PokemonListProps) => {
-  const now = usePokemonsStore((state) => state.now);
-
+export const PokemonList = ({ pokemonIdsList, now }: PokemonListProps) => {
   const { isLoading, error, data } = useQuery<PokemonsResponseProps>({
     queryKey: ['pokemons', now],
     queryFn: () => getPokemons(now),
-    enabled: !pokemonId,
+    enabled: !pokemonIdsList,
   });
-
   if (isLoading) return <div>loading...</div>;
   if (error) return <div>error</div>;
   if (data)
     return (
       <>
         <div className="grid grid-cols-5 py-2 px-14 gap-8">
-          {pokemonId && <Pokemon id={pokemonId} />}
-          {!pokemonId &&
+          {pokemonIdsList &&
+            pokemonIdsList.map((pokemonId) => (
+              <Pokemon key={pokemonId} id={pokemonId} />
+            ))}
+          {!pokemonIdsList &&
             data.data.map((pokemon) => (
               <Pokemon
                 key={extractIdFromUrl(pokemon.url)}
@@ -39,8 +37,6 @@ export const PokemonList = ({ pokemonId }: PokemonListProps) => {
               />
             ))}
         </div>
-
-        <PagingDocuments />
       </>
     );
 };

--- a/src/components/PokemonSearchForm/PokemonSearchForm.tsx
+++ b/src/components/PokemonSearchForm/PokemonSearchForm.tsx
@@ -1,9 +1,6 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { useForm } from 'react-hook-form';
-import { useQuery } from '@tanstack/react-query';
-
-import { getPokemonIdByKoreanName } from '@/api/pokemon';
 
 import usePokemonsStore from '@/stores/pokemonsStore';
 
@@ -23,47 +20,43 @@ export const PokemonSearchForm = () => {
     now,
     total,
     last,
-    search,
     searchIdsList,
     setNow,
     setTotal,
     setLast,
-    setSearch,
     setSearchIdsList,
   } = usePokemonsStore();
 
+  const [pokemonIdsList, setPokemonIdsList] = useState<number[] | null>(null);
   const { register, handleSubmit, reset } = useForm<InputValues>();
 
-  const { isLoading: isSearchLoading, data } = useQuery({
-    queryKey: ['searchPokemon', search],
-    queryFn: () => getPokemonIdByKoreanName(search as string),
-    retry: 1,
-    enabled: search !== null,
-  });
-
   useEffect(() => {
-    if (search) {
-      setSearchIdsList(getPokemonsByPartialName(search));
-      return;
+    if (searchIdsList) {
+      return setPokemonIdsList(
+        searchIdsList.slice((now - 1) * 10, (now - 1) * 10 + 10),
+      );
     }
-    setSearchIdsList(null);
-  }, [search]);
+    return setPokemonIdsList(null);
+  }, [searchIdsList, now]);
 
   const handleSearchSubmit = (input: InputValues) => {
-    setSearch(input.keyword.trim());
-    setTotal(1);
-    setLast(true);
+    const pokemonIds = getPokemonsByPartialName(input.keyword.trim());
+    setSearchIdsList(pokemonIds);
+    setTotal(pokemonIds.length);
+    setNow(1);
   };
 
   const handleResetSubmit = () => {
     reset();
-    setLast(false);
-    setNow(1);
+    setSearchIdsList(null);
     setTotal(TOTAL_POKEMON_NUM);
-    setSearch(null);
+    setNow(1);
   };
 
-  if (isSearchLoading) return <div>search loading...</div>;
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+    if (value.trim() === '') handleResetSubmit();
+  };
 
   return (
     <>
@@ -74,31 +67,28 @@ export const PokemonSearchForm = () => {
           required={true}
           register={register}
           className="min-w-[297px]"
+          onChange={handleInputChange}
         />
-        <Button
-          primary={true}
-          type="submit"
-          size="small"
-          label="검색"
-          disabled={isSearchLoading}
-        />
+        <Button primary={true} type="submit" size="small" label="검색" />
         <Button
           primary={false}
           type="reset"
           size="small"
           label="초기화"
-          disabled={isSearchLoading}
           onClick={handleSubmit(handleResetSubmit)}
         />
       </form>
-      <PokemonList pokemonIdsList={searchIdsList} now={now} />
+      <PokemonList pokemonIdsList={pokemonIdsList} now={now} />
       <PagingDocuments
         now={now}
         last={last}
         total={total}
         setNow={setNow}
         setLast={setLast}
+        pageSize={PAGE_ITEM_SIZE}
       />
     </>
   );
 };
+
+const PAGE_ITEM_SIZE = 10;

--- a/src/components/PokemonSearchForm/PokemonSearchForm.tsx
+++ b/src/components/PokemonSearchForm/PokemonSearchForm.tsx
@@ -10,20 +10,26 @@ import usePokemonsStore from '@/stores/pokemonsStore';
 import { SearchInput } from '../SearchInput/SearchInput';
 import { Button } from '../Button/Button';
 import { PokemonList } from '../PokemonList/PokemonList';
+import { PagingDocuments } from '../PagingDocuments/PagingDocuments';
 
 import { InputValues } from '@/types/common';
+
+import getPokemonsByPartialName from '@/utils/getPokemonsIdByPartialName';
 
 import { TOTAL_POKEMON_NUM } from '@/constants/contents';
 
 export const PokemonSearchForm = () => {
   const {
-    setTotal,
-    setSearch,
-    setNow,
-    setLast,
+    now,
+    total,
+    last,
     search,
-    searchId,
-    setSearchId,
+    searchIdsList,
+    setNow,
+    setTotal,
+    setLast,
+    setSearch,
+    setSearchIdsList,
   } = usePokemonsStore();
 
   const { register, handleSubmit, reset } = useForm<InputValues>();
@@ -36,13 +42,12 @@ export const PokemonSearchForm = () => {
   });
 
   useEffect(() => {
-    if (search && data) {
-      setSearchId(data);
+    if (search) {
+      setSearchIdsList(getPokemonsByPartialName(search));
       return;
     }
-
-    setSearchId(null);
-  }, [search, data]);
+    setSearchIdsList(null);
+  }, [search]);
 
   const handleSearchSubmit = (input: InputValues) => {
     setSearch(input.keyword.trim());
@@ -86,7 +91,14 @@ export const PokemonSearchForm = () => {
           onClick={handleSubmit(handleResetSubmit)}
         />
       </form>
-      <PokemonList pokemonId={searchId} />
+      <PokemonList pokemonIdsList={searchIdsList} now={now} />
+      <PagingDocuments
+        now={now}
+        last={last}
+        total={total}
+        setNow={setNow}
+        setLast={setLast}
+      />
     </>
   );
 };

--- a/src/components/PokemonSearchForm/PokemonSearchForm.tsx
+++ b/src/components/PokemonSearchForm/PokemonSearchForm.tsx
@@ -8,6 +8,7 @@ import { SearchInput } from '../SearchInput/SearchInput';
 import { Button } from '../Button/Button';
 import { PokemonList } from '../PokemonList/PokemonList';
 import { PagingDocuments } from '../PagingDocuments/PagingDocuments';
+import { Tooltip } from '../Tooltip/Tooltip';
 
 import { InputValues } from '@/types/common';
 
@@ -17,19 +18,10 @@ import {
   POKEMON_PAGE_ITEM_SIZE,
   TOTAL_POKEMON_NUM,
 } from '@/constants/contents';
-import { Tooltip } from '../Tooltip/Tooltip';
 
 export const PokemonSearchForm = () => {
-  const {
-    now,
-    total,
-    last,
-    searchIdsList,
-    setNow,
-    setTotal,
-    setLast,
-    setSearchIdsList,
-  } = usePokemonsStore();
+  const { now, total, searchIdsList, setNow, setTotal, setSearchIdsList } =
+    usePokemonsStore();
 
   const {
     register,
@@ -64,9 +56,6 @@ export const PokemonSearchForm = () => {
     setNow(1);
   };
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.value === '') clearErrors('keyword'); // 입력값 변경 시 에러 초기화
-  };
   return (
     <>
       <form
@@ -77,7 +66,6 @@ export const PokemonSearchForm = () => {
             placeholder="포켓몬 검색"
             register={register}
             setValue={setValue}
-            onChange={handleChange}
             className="min-w-[297px]"
           />
           {errors.keyword && (
@@ -92,7 +80,6 @@ export const PokemonSearchForm = () => {
           type="reset"
           size="small"
           label="초기화"
-          disabled={pokemonIdsList === null}
           onClick={handleResetSubmit}
         />
         <Tooltip
@@ -103,10 +90,8 @@ export const PokemonSearchForm = () => {
       <PokemonList pokemonIdsList={pokemonIdsList} now={now} />
       <PagingDocuments
         now={now}
-        last={last}
         total={total}
         setNow={setNow}
-        setLast={setLast}
         pageSize={POKEMON_PAGE_ITEM_SIZE}
       />
     </>

--- a/src/components/PokemonSearchForm/PokemonSearchForm.tsx
+++ b/src/components/PokemonSearchForm/PokemonSearchForm.tsx
@@ -13,7 +13,11 @@ import { InputValues } from '@/types/common';
 
 import getPokemonsByPartialName from '@/utils/getPokemonsIdByPartialName';
 
-import { TOTAL_POKEMON_NUM } from '@/constants/contents';
+import {
+  POKEMON_PAGE_ITEM_SIZE,
+  TOTAL_POKEMON_NUM,
+} from '@/constants/contents';
+import { Tooltip } from '../Tooltip/Tooltip';
 
 export const PokemonSearchForm = () => {
   const {
@@ -27,16 +31,23 @@ export const PokemonSearchForm = () => {
     setSearchIdsList,
   } = usePokemonsStore();
 
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    reset,
+    clearErrors,
+    formState: { errors },
+  } = useForm<InputValues>();
+
   const [pokemonIdsList, setPokemonIdsList] = useState<number[] | null>(null);
-  const { register, handleSubmit, reset } = useForm<InputValues>();
 
   useEffect(() => {
     if (searchIdsList) {
-      return setPokemonIdsList(
-        searchIdsList.slice((now - 1) * 10, (now - 1) * 10 + 10),
-      );
+      setPokemonIdsList(searchIdsList.slice((now - 1) * 10, now * 10));
+    } else {
+      setPokemonIdsList(null);
     }
-    return setPokemonIdsList(null);
   }, [searchIdsList, now]);
 
   const handleSearchSubmit = (input: InputValues) => {
@@ -53,29 +64,40 @@ export const PokemonSearchForm = () => {
     setNow(1);
   };
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { value } = e.target;
-    if (value.trim() === '') handleResetSubmit();
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.value === '') clearErrors('keyword'); // 입력값 변경 시 에러 초기화
   };
-
   return (
     <>
       <form
         className="flex justify-center gap-[10px] w-full px-80 py-2 mb-6"
         onSubmit={handleSubmit(handleSearchSubmit)}>
-        <SearchInput
-          required={true}
-          register={register}
-          className="min-w-[297px]"
-          onChange={handleInputChange}
-        />
+        <div className="relative">
+          <SearchInput
+            placeholder="포켓몬 검색"
+            register={register}
+            setValue={setValue}
+            onChange={handleChange}
+            className="min-w-[297px]"
+          />
+          {errors.keyword && (
+            <p className="text-red-10 font-bold text-sm absolute left-0 mt-1">
+              {errors.keyword.message}
+            </p>
+          )}
+        </div>
         <Button primary={true} type="submit" size="small" label="검색" />
         <Button
           primary={false}
           type="reset"
           size="small"
           label="초기화"
-          onClick={handleSubmit(handleResetSubmit)}
+          disabled={pokemonIdsList === null}
+          onClick={handleResetSubmit}
+        />
+        <Tooltip
+          text="전체 목록으로 돌아가시려면 초기화 버튼을 클릭해주세요."
+          visible={!!errors.keyword}
         />
       </form>
       <PokemonList pokemonIdsList={pokemonIdsList} now={now} />
@@ -85,10 +107,8 @@ export const PokemonSearchForm = () => {
         total={total}
         setNow={setNow}
         setLast={setLast}
-        pageSize={PAGE_ITEM_SIZE}
+        pageSize={POKEMON_PAGE_ITEM_SIZE}
       />
     </>
   );
 };
-
-const PAGE_ITEM_SIZE = 10;

--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -32,6 +32,7 @@ export const SearchInput = ({
         className,
       )}
       placeholder={placeholder}
+      autoComplete="off"
       {...register('keyword', {
         required: '포켓몬을 입력해주세요.',
         validate: (value) => value.trim() !== '' || '공백은 검색할 수 없어요.',

--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -9,6 +9,7 @@ export interface SearchInputProps extends DefaultProps {
   placeholder?: string;
   register: UseFormRegister<InputValues>;
   onClick?: () => void;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 export const SearchInput = ({
@@ -17,6 +18,7 @@ export const SearchInput = ({
   placeholder,
   className,
   register,
+  onChange,
 }: SearchInputProps) => {
   const SearchInputSize: Record<SearchInputSize, string> = {
     small: 'px-2 py-1 rounded-lg text-xs border',
@@ -33,6 +35,7 @@ export const SearchInput = ({
         className,
       )}
       {...register('keyword')}
+      onChange={onChange}
     />
   );
 };

--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -1,23 +1,22 @@
-import { UseFormRegister } from 'react-hook-form';
+import { UseFormRegister, UseFormSetValue } from 'react-hook-form';
 import { twJoin } from 'tailwind-merge';
 
 import { DefaultProps, InputValues, SearchInputSize } from '@/types/common';
 
 export interface SearchInputProps extends DefaultProps {
-  required?: boolean;
   size?: SearchInputSize;
   placeholder?: string;
   register: UseFormRegister<InputValues>;
-  onClick?: () => void;
+  setValue: UseFormSetValue<InputValues>; // react-hook-form의 setValue 추가
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 export const SearchInput = ({
-  required = false,
   size = 'medium',
   placeholder,
   className,
   register,
+  setValue,
   onChange,
 }: SearchInputProps) => {
   const SearchInputSize: Record<SearchInputSize, string> = {
@@ -27,15 +26,21 @@ export const SearchInput = ({
 
   return (
     <input
-      placeholder={placeholder}
-      required={required}
       className={twJoin(
         'w-full border-gray-30 focus:outline-blue-30 font-light shadow-md',
         SearchInputSize[size],
         className,
       )}
-      {...register('keyword')}
-      onChange={onChange}
+      placeholder={placeholder}
+      {...register('keyword', {
+        required: '포켓몬을 입력해주세요.',
+        validate: (value) => value.trim() !== '' || '공백은 검색할 수 없어요.',
+        onChange: (e) => {
+          // react-hook-form의 동작과 커스텀 핸들러 병합
+          setValue('keyword', e.target.value); // react-hook-form 상태 업데이트
+          onChange?.(e); // 커스텀 onChange 실행
+        },
+      })}
     />
   );
 };

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -4,21 +4,22 @@ import { FaQuestionCircle } from 'react-icons/fa';
 
 export interface AbilityBoxProps {
   text: string;
+  visible?: boolean;
 }
 
-export const Tooltip = ({ text }: AbilityBoxProps) => {
-  const [visible, setVisible] = useState(false);
+export const Tooltip = ({ text, visible = true }: AbilityBoxProps) => {
+  const [show, setShow] = useState(false);
 
   const handleMouseEnter = () => {
-    setVisible(true);
+    setShow(true);
   };
 
   const handleMouseLeave = () => {
-    setVisible(false);
+    setShow(false);
   };
   return (
     <div
-      className="relative inline-block"
+      className={`relative inline-block ${visible ? ' visible' : 'invisible'}`}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}>
       <FaQuestionCircle
@@ -27,7 +28,7 @@ export const Tooltip = ({ text }: AbilityBoxProps) => {
       />
       <div
         className={`absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 w-max bg-black-10 text-white-100 text-xs rounded px-2 py-1 z-10 transition-opacity duration-400 ${
-          visible ? 'opacity-100' : 'opacity-0 pointer-events-none'
+          show ? 'opacity-100' : 'opacity-0 pointer-events-none'
         }`}>
         {text}
       </div>

--- a/src/components/TypeBadge/TypeBadge.tsx
+++ b/src/components/TypeBadge/TypeBadge.tsx
@@ -43,6 +43,6 @@ export const TypeBadge = ({ type, size }: TypeBadgeProps) => {
 };
 
 const TYPE_BADGE_SIZE: TypeBadgeSizeProps = {
-  small: 'text-xs font-bold px-4 py-1 rounded-lg',
+  small: 'text-xs font-bold px-3 py-1 rounded-lg',
   medium: 'text-[16px] px-4 py-2 rounded-lg font-bold w-fit',
 };

--- a/src/constants/contents.ts
+++ b/src/constants/contents.ts
@@ -2,6 +2,8 @@ import { PokemonType, StatKey } from '@/types/common';
 
 export const TOTAL_POKEMON_NUM = 1025;
 
+export const POKEMON_PAGE_ITEM_SIZE = 10;
+
 export const DEFENCE_ABILITY = [
   '건조피부',
   '내열',

--- a/src/hooks/usePagination.tsx
+++ b/src/hooks/usePagination.tsx
@@ -5,7 +5,6 @@ export const usePagination = (
   now: number,
   size: number,
   setNow: (num: number) => void,
-  setLast: (val: boolean) => void,
 ) => {
   const [pages, setPages] = useState<number[]>([]);
 
@@ -17,15 +16,12 @@ export const usePagination = (
     }
 
     if (now <= 3) {
-      setLast(false);
       setPages([1, 2, 3, 4, 5]);
     } else if (totalPages === now) {
-      setLast(true);
       setPages([now - 4, now - 3, now - 2, now - 1, now]);
     } else if (totalPages - 1 <= now) {
       setPages([now - 3, now - 2, now - 1, now, now + 1]);
     } else {
-      setLast(false);
       setPages([now - 2, now - 1, now, now + 1, now + 2]);
     }
   }, [now, total]);
@@ -34,15 +30,12 @@ export const usePagination = (
     const totalPages = Math.ceil(total / size);
     if (pageNum < 0) return setNow(1);
     if (pageNum > totalPages) {
-      setNow(totalPages);
-      return setLast(true);
+      return setNow(totalPages);
     }
     if (pageNum === totalPages) {
-      setNow(pageNum);
-      return setLast(true);
+      return setNow(pageNum);
     }
-    setNow(pageNum);
-    return setLast(false);
+    return setNow(pageNum);
   };
 
   return { pages, goToPage };

--- a/src/stores/pokemonsStore.tsx
+++ b/src/stores/pokemonsStore.tsx
@@ -4,14 +4,12 @@ import { TOTAL_POKEMON_NUM } from '@/constants/contents';
 import { PokemonDataProps } from '@/types/common';
 
 interface PokemonsState {
-  last: boolean;
   now: number;
   total: number;
   search: string | null;
   searchIdsList: number[] | null;
   targetPokemon: PokemonDataProps | null;
 
-  setLast: (last: boolean) => void;
   setNow: (now: number) => void;
   setTotal: (total: number) => void;
   setSearch: (search: string | null) => void;
@@ -20,14 +18,12 @@ interface PokemonsState {
 }
 
 const usePokemonsStore = create<PokemonsState>((set) => ({
-  last: false,
   now: 1,
   total: TOTAL_POKEMON_NUM,
   search: null,
   searchIdsList: null,
   targetPokemon: null,
 
-  setLast: (last) => set(() => ({ last })),
   setNow: (now) => set(() => ({ now })),
   setTotal: (total) => set(() => ({ total })),
   setSearch: (search) => set(() => ({ search })),

--- a/src/stores/pokemonsStore.tsx
+++ b/src/stores/pokemonsStore.tsx
@@ -8,14 +8,14 @@ interface PokemonsState {
   now: number;
   total: number;
   search: string | null;
-  searchId: number | null;
+  searchIdsList: number[] | null;
   targetPokemon: PokemonDataProps | null;
 
   setLast: (last: boolean) => void;
   setNow: (now: number) => void;
   setTotal: (total: number) => void;
   setSearch: (search: string | null) => void;
-  setSearchId: (search: number | null) => void;
+  setSearchIdsList: (searchList: number[] | null) => void;
   setTargetPokemon: (targetPokemon: PokemonDataProps | null) => void;
 }
 
@@ -24,14 +24,14 @@ const usePokemonsStore = create<PokemonsState>((set) => ({
   now: 1,
   total: TOTAL_POKEMON_NUM,
   search: null,
-  searchId: null,
+  searchIdsList: null,
   targetPokemon: null,
 
   setLast: (last) => set(() => ({ last })),
   setNow: (now) => set(() => ({ now })),
   setTotal: (total) => set(() => ({ total })),
   setSearch: (search) => set(() => ({ search })),
-  setSearchId: (searchId) => set(() => ({ searchId })),
+  setSearchIdsList: (searchIdsList) => set(() => ({ searchIdsList })),
   setTargetPokemon: (targetPokemon) => set(() => ({ targetPokemon })),
 }));
 

--- a/src/utils/getPokemonsIdByPartialName.ts
+++ b/src/utils/getPokemonsIdByPartialName.ts
@@ -1,7 +1,6 @@
 import { POKEMON_LIST_IN_KOREAN } from '@/constants/contents';
 
 export default function getPokemonsByPartialName(input: string): number[] {
-  console.log(input);
   return POKEMON_LIST_IN_KOREAN.map((word, index) =>
     word.includes(input) ? index + 1 : -1,
   ).filter((index) => index !== -1);

--- a/src/utils/getPokemonsIdByPartialName.ts
+++ b/src/utils/getPokemonsIdByPartialName.ts
@@ -1,0 +1,8 @@
+import { POKEMON_LIST_IN_KOREAN } from '@/constants/contents';
+
+export default function getPokemonsByPartialName(input: string): number[] {
+  console.log(input);
+  return POKEMON_LIST_IN_KOREAN.map((word, index) =>
+    word.includes(input) ? index + 1 : -1,
+  ).filter((index) => index !== -1);
+}


### PR DESCRIPTION
## Abstracts
* 포켓몬 목록 페이지에서 검색 로직을 수정합니다.

## Description
* 포켓몬 일부 검색으로 모든 결과 노출 (파 -> 파이리, 파이어 등)
* 검색 로직 수정으로 발생한 페이지네이션 오류 수정
* 검색 시 밸리데이션 체크 및 에러메시지 출력 

## Discussion
* 


